### PR TITLE
fix: DeepSeek V4 multi-turn tool call thinking token replay

### DIFF
--- a/src/providers/common/genericModelProvider.ts
+++ b/src/providers/common/genericModelProvider.ts
@@ -927,14 +927,33 @@ export class GenericModelProvider implements LanguageModelChatProvider {
                 );
         }
 
-        // Find corresponding model configuration
-        const modelConfig = this.providerConfig.models.find(
+        // Find corresponding model configuration.
+        // Prefer cachedProviderConfig (which has auto-detection applied) over static providerConfig.
+        const effectiveModels =
+            this.cachedProviderConfig?.models || this.providerConfig.models;
+        let modelConfig = effectiveModels.find(
             (m: ModelConfig) => m.id === model.id || m.model === model.id
         );
+
+        // If model config not found, create a fallback with auto-detection for DeepSeek
         if (!modelConfig) {
-            const errorMessage = `Model not found: ${model.id}`;
-            Logger.error(errorMessage);
-            throw new Error(errorMessage);
+            const includeThinking = requiresThinkingContentRoundTrip(
+                `${model.id} ${model.name || ''} ${model.tooltip || ''}`
+            );
+            Logger.warn(
+                `Model config not found for ${model.id}, using fallback config. includeThinking=${includeThinking}`
+            );
+            modelConfig = {
+                id: model.id,
+                name: model.name,
+                tooltip: model.tooltip || model.name,
+                maxInputTokens: model.maxInputTokens,
+                maxOutputTokens: model.maxOutputTokens,
+                model: model.version || model.id,
+                baseUrl: this.providerConfig.baseUrl,
+                capabilities: model.capabilities,
+                ...(includeThinking && { includeThinking: true })
+            };
         }
 
         // Determine actual provider based on provider field in model configuration

--- a/src/providers/opencodego/provider.ts
+++ b/src/providers/opencodego/provider.ts
@@ -23,6 +23,7 @@ import { ApiKeyManager, Logger, RateLimiter } from '../../utils';
 import {
     DEFAULT_CONTEXT_LENGTH,
     DEFAULT_MAX_OUTPUT_TOKENS,
+    requiresThinkingContentRoundTrip,
     resolveGlobalCapabilities,
     resolveGlobalTokenLimits
 } from '../../utils/globalContextLengthManager';
@@ -218,6 +219,14 @@ export class OpenCodeGoProvider
             this.cachedModelConfigs.find((m) => m.id === model.id) ||
             this.providerConfig.models?.find((m) => m.id === model.id);
 
+        // Build fallback config with auto-detection for DeepSeek models.
+        // The includeThinking flag is lost during ModelConfig → LanguageModelChatInformation
+        // conversion, so we must re-detect it at request time to ensure DeepSeek API
+        // receives reasoning_content in replayed assistant messages.
+        const fallbackIncludeThinking = requiresThinkingContentRoundTrip(
+            `${model.id} ${model.name || ''} ${model.tooltip || ''}`
+        );
+
         await this.openaiHandler.handleRequest(
             model,
             modelConfig || {
@@ -228,7 +237,8 @@ export class OpenCodeGoProvider
                 maxOutputTokens: model.maxOutputTokens,
                 model: model.version || model.id,
                 baseUrl: this.providerConfig.baseUrl,
-                capabilities: model.capabilities
+                capabilities: model.capabilities,
+                ...(fallbackIncludeThinking && { includeThinking: true })
             },
             messages,
             options,


### PR DESCRIPTION
Fix DeepSeek V4 models failing on turn 3+ of multi-turn tool calls with 400 error "reasoning_content must be passed back to the API".

The includeThinking flag was set at model-fetch time but lost during the ModelConfig → LanguageModelChatInformation round-trip in executeRequest(). The fallback config omitted includeThinking, so convertAssistantMessage() never injected reasoning_content into replayed assistant messages containing tool_calls.

Changes:
- opencodego/provider.ts: Fallback config now auto-detects DeepSeek models via requiresThinkingContentRoundTrip() and sets includeThinking
- genericModelProvider.ts: Uses cachedProviderConfig.models (with auto-detection) instead of static providerConfig.models; creates fallback ModelConfig with includeThinking when model not found

Testing:
- 3-turn smoke test (create → edit → read) executed successfully with both deepseek-v4-flash and deepseek-v4-pro via OpenAI transport through OpenCode Go provider
- VSIX package built and installed on developer's VS Code instance; extension continues to work without error across multiple sessions